### PR TITLE
Fix for latest TriliumNext

### DIFF
--- a/src/content.less
+++ b/src/content.less
@@ -36,3 +36,15 @@
         }
     }
 }
+
+.note-detail-readonly-code-content {
+    padding: 0px !important;
+}
+
+.bx-lg {
+    overflow: visible !important;
+}
+
+.bx-lg::before {
+    transform: translate(-25%, -80%);
+}

--- a/src/content.less
+++ b/src/content.less
@@ -11,7 +11,6 @@
     code {
         background: transparent !important;
         color: var(--breeze-link-color) !important;
-        font-size: 1rem;
         padding: 0;
     }
 

--- a/src/editor.less
+++ b/src/editor.less
@@ -54,7 +54,7 @@
 
 // Selects the main container of the editor, to add a full size border around it.
 // TODO: Prone to breaking between versions, but no other way since there is no unique class attached to this.
-.split-note-container-widget .component.mermaid-widget + .component {
+.floating-buttons + .component {
     --main-background-color: var(--breeze-input-background);
     background: var(--main-background-color);
     border: 1px solid var(--breeze-input-border);

--- a/src/master.less
+++ b/src/master.less
@@ -25,6 +25,16 @@
     flex-wrap: wrap;
 }
 
-#left-pane, #rest-pane {
+#left-pane {
     height: calc(100% - var(--breeze-toolbar-height)) !important;
+    align-self: end;
+}
+
+#rest-pane {
+    height: calc(100% - var(--breeze-toolbar-height));
+    align-self: end;
+}
+
+.zen #rest-pane {
+    height: 100% !important;
 }

--- a/src/ribbon.less
+++ b/src/ribbon.less
@@ -152,9 +152,7 @@
 }
 
 .ribbon-container .ribbon-button-container {
-    position: absolute;
-    top: 85px;
-    right: var(--ribbon-button-right-margin);
+    height: 28px;
     border: 0;
     margin: 0;
 

--- a/src/toolbar.less
+++ b/src/toolbar.less
@@ -6,10 +6,15 @@
     box-sizing: border-box;
     padding: 7px 8px !important;
     --hover-item-background-color: var(--breeze-toolbutton-hover-background-color);
+    position: absolute !important;
 }
 
 body:focus-within {
     --launcher-pane-background-color: var(--breeze-titlebar-active-background);
+}
+
+.spacer {
+    -webkit-app-region: drag;
 }
 
 #launcher-pane .spacer {
@@ -20,6 +25,11 @@ body:focus-within {
     &+.spacer {
         display: none !important;
     }
+}
+
+// HACK to find and grow the last spacer in the toolbar (it must be bigger to ensure the window can be dragged)
+#launcher-pane .bx-cog + .spacer {
+    flex-grow: 1 !important;
 }
 
 #launcher-pane .launcher-button,
@@ -137,6 +147,10 @@ body:focus-within {
         }
     }
 
+    .dropdown-menu {
+        transform: translate(-100%, 0) !important;
+    }
+
     .dropdown-submenu > .dropdown-menu {
         left: 0;
         transform: translateX(calc(-100% - 3px));
@@ -206,8 +220,8 @@ body:focus-within {
     }
 }
 
-.tooltip.bs-tooltip-right {
+.tooltip.bs-tooltip-auto[data-popper-placement="right"] {
     position: absolute;
-    left: calc(-4px + calc(-1 * var(--breeze-iconbutton-width))) !important;
+    left: calc(-6px + calc(-1 * var(--breeze-iconbutton-width))) !important;
     top: var(--breeze-iconbutton-width) !important;
 }


### PR DESCRIPTION
In order of the `git diff`:

Fixes visible padding around read-only notes.
Fixes enlarged edit button animation for read-only notes.
Fixes main note component not found (precise selector changed once again).
Fixes height override of panels.
Fixes Zen mode height override.
Fixes toolbar position.
Fixes window drag ability.
Fixes dropdown menu location (closes #15).
Fixes toolbar tooltip location.